### PR TITLE
Exclude visa-checkout from braintree-android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,11 +32,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta01'
     implementation 'com.google.android.material:material:1.0.0'
 
-    // comment out the braintree dependency to get rid of this compilation error:
-
-    // Execution failed for task ':app:compileDebugJavaWithJavac'.
-    // > android.databinding.tool.util.LoggedErrorException: Found data binding errors.
-    // Unknown class: java.lang.String
-    // file:///private/tmp/myapp/MyApplication/app/src/main/res/layout/activity_main.xml Line:28
-    implementation 'com.braintreepayments.api:braintree:2.17.0'
+    implementation('com.braintreepayments.api:braintree:2.17.0') {
+      exclude module: 'visa-checkout'
+    }
 }

--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -1,18 +1,31 @@
 package com.example.myapplication;
 
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.braintreepayments.api.BraintreeFragment;
+import com.braintreepayments.api.Card;
+import com.braintreepayments.api.exceptions.InvalidArgumentException;
+import com.braintreepayments.api.interfaces.BraintreeErrorListener;
+import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
+import com.braintreepayments.api.models.CardBuilder;
+import com.braintreepayments.api.models.PaymentMethodNonce;
+import com.example.myapplication.databinding.ActivityMainBinding;
+
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.databinding.DataBindingUtil;
 import androidx.databinding.Observable;
 import androidx.databinding.ObservableField;
-import androidx.databinding.ViewDataBinding;
-import androidx.appcompat.app.AppCompatActivity;
-import android.os.Bundle;
-import android.util.Log;
 
-import com.example.myapplication.databinding.ActivityMainBinding;
-
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements PaymentMethodNonceCreatedListener,
+        BraintreeErrorListener {
 
     private static final String TAG = MainActivity.class.getSimpleName();
+
+    // Stolen from: https://github.com/braintree/braintree_android/blob/master/Demo/src/main/java/com/braintreepayments/demo/Settings.java#L19
+    private static final String SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn";
+    private BraintreeFragment mBraintreeFragment;
 
     // Should be a viewmodel but just going for simplicity to reproduce the bug
     public static class Model {
@@ -31,5 +44,26 @@ public class MainActivity extends AppCompatActivity {
                 Log.v(TAG, "inputText changed: " + model.inputText.get());
             }
         });
+
+        try {
+            mBraintreeFragment = BraintreeFragment.newInstance(this,
+                    SANDBOX_TOKENIZATION_KEY);
+        } catch (InvalidArgumentException e) {
+            onError(e);
+        }
+
+        Card.tokenize(mBraintreeFragment, new CardBuilder()
+                        .cardNumber("4111111111111111"));
+    }
+
+    @Override
+    public void onPaymentMethodNonceCreated(PaymentMethodNonce paymentMethodNonce) {
+        Toast.makeText(this, "Success " + paymentMethodNonce.getNonce(),
+                Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onError(Exception error) {
+        throw new RuntimeException(error);
     }
 }


### PR DESCRIPTION
Visa Checkout uses databinding and seems to be a blocker for the
AndroidX upgrade. Excluding the package from braintree.

This will prevent merchants from processing Visa Checkout until it is
fixed but this is a temporary fix.

Also including a test Card tokenization to verify that Braintree's
tokenization flow works with AndroidX.